### PR TITLE
Couple of changes to the script editor

### DIFF
--- a/EditorWindow.cs
+++ b/EditorWindow.cs
@@ -216,7 +216,16 @@ namespace Telltale_Script_Editor
             }
 
             var archive = Prompt.ShowDialog("What archive should the script be created in?", "Create new Script");
+
+            //if the user exists the prompt, the string will be empty, so do not continue
+            if (string.IsNullOrEmpty(archive) || string.IsNullOrWhiteSpace(archive))
+                return;
+
             var scriptName = Prompt.ShowDialog("What should the script be called?", "Create new Script");
+
+            //if the user exists the prompt, the string will be empty, so do not continue
+            if (string.IsNullOrEmpty(scriptName) || string.IsNullOrWhiteSpace(scriptName))
+                return;
 
             if (!scriptName.EndsWith(".lua"))
                 scriptName += ".lua";

--- a/EditorWindow.cs
+++ b/EditorWindow.cs
@@ -207,6 +207,37 @@ namespace Telltale_Script_Editor
             }
         }
 
+        /// <summary>
+        /// Gets the 'archive' folders in the project
+        /// </summary>
+        /// <returns></returns>
+        private List<string> GetArchiveFolders()
+        {
+            //temp list to contain our 'archives'
+            List<string> result = new List<string>();
+
+            //get the build and temporary folder directory (since apparently these are the only ones in the project not included in the project building)
+            var buildDirectory = $"{WorkingDirectory}\\Builds";
+            var tempDirectory = $"{buildDirectory}\\Temp";
+
+            //run a loop to go through all of the directories in the project working directory
+            foreach (string dirPath in Directory.GetDirectories(WorkingDirectory, "*", SearchOption.AllDirectories))
+            {
+                //if the current path is not the 'build directory' or 'temp directory' then we found an archive folder
+                if (dirPath != buildDirectory && dirPath != tempDirectory)
+                {
+                    //get the name of the folder
+                    string directoryName = dirPath.Remove(0, Directory.GetParent(dirPath).FullName.Length + 1);
+
+                    //add the name of the folder
+                    result.Add(directoryName);
+                }
+            }
+
+            //return the final list
+            return result;
+        }
+
         private void scriptToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if(fileManager == null)
@@ -215,7 +246,11 @@ namespace Telltale_Script_Editor
                 return;
             }
 
-            var archive = Prompt.ShowDialog("What archive should the script be created in?", "Create new Script");
+            //gets the list of the archive folder names (to be used for the dropdown)
+            List<string> archiveNames = GetArchiveFolders();
+
+            //opens a dropdown prompt with the 'archiveNames' as the dropdown items
+            var archive = Prompt_Dropdown.ShowDialog("What archive should the script be created in?", "Create new Script", archiveNames);
 
             //if the user exists the prompt, the string will be empty, so do not continue
             if (string.IsNullOrEmpty(archive) || string.IsNullOrWhiteSpace(archive))

--- a/EditorWindow.cs
+++ b/EditorWindow.cs
@@ -250,7 +250,7 @@ namespace Telltale_Script_Editor
             List<string> archiveNames = GetArchiveFolders();
 
             //opens a dropdown prompt with the 'archiveNames' as the dropdown items
-            var archive = Prompt_Dropdown.ShowDialog("What archive should the script be created in?", "Create new Script", archiveNames);
+            var archive = Prompt_Dropdown.ShowDialog("Select an existing archive for the script location.\nOr write a new one into the field.", "Create new Script", archiveNames);
 
             //if the user exists the prompt, the string will be empty, so do not continue
             if (string.IsNullOrEmpty(archive) || string.IsNullOrWhiteSpace(archive))

--- a/Telltale Script Editor.csproj
+++ b/Telltale Script Editor.csproj
@@ -73,6 +73,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\GUI\Prompt_Dropdown.cs" />
     <Compile Include="Util\JSON\EditorProject.cs" />
     <Compile Include="Util\FileManagement\FileManagement.cs" />
     <Compile Include="Util\FileManagement\SOExtension.cs" />

--- a/Util/GUI/Prompt_Dropdown.cs
+++ b/Util/GUI/Prompt_Dropdown.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Telltale_Script_Editor.Util.GUI
+{
+    public static class Prompt_Dropdown
+    {
+        public static string ShowDialog(string text, string caption, List<string> comboboxItems)
+        {
+            Form prompt = new Form()
+            {
+                Width = 500,
+                Height = 150,
+                FormBorderStyle = FormBorderStyle.FixedDialog,
+                Text = caption,
+                StartPosition = FormStartPosition.CenterScreen
+            };
+            Label textLabel = new Label() { Left = 50, Top = 20, Text = text, AutoSize = true };
+            ComboBox comboBox = new ComboBox() { Left = 50, Top = 50, Width = 400 };
+
+            foreach(string item in comboboxItems)
+            {
+                comboBox.Items.Add(item);
+            }
+
+            Button confirmation = new Button() { Text = "Ok", Left = 350, Width = 100, Top = 70, DialogResult = DialogResult.OK };
+            confirmation.Click += (sender, e) => { prompt.Close(); };
+            prompt.Controls.Add(comboBox);
+            prompt.Controls.Add(confirmation);
+            prompt.Controls.Add(textLabel);
+            prompt.AcceptButton = confirmation;
+
+            return prompt.ShowDialog() == DialogResult.OK ? comboBox.SelectedItem.ToString() : "";
+        }
+    }
+}

--- a/Util/GUI/Prompt_Dropdown.cs
+++ b/Util/GUI/Prompt_Dropdown.cs
@@ -22,7 +22,7 @@ namespace Telltale_Script_Editor.Util.GUI
             Label textLabel = new Label() { Left = 50, Top = 20, Text = text, AutoSize = true };
 
             //create a new combobox
-            ComboBox comboBox = new ComboBox() { Left = 50, Top = 50, Width = 400, DropDownStyle = ComboBoxStyle.DropDownList };
+            ComboBox comboBox = new ComboBox() { Left = 50, Top = 50, Width = 400, DropDownStyle = ComboBoxStyle.DropDown };
 
             //run a loop to add each of the combobox items string into the actual combobox element
             foreach (string item in comboboxItems)

--- a/Util/GUI/Prompt_Dropdown.cs
+++ b/Util/GUI/Prompt_Dropdown.cs
@@ -20,9 +20,12 @@ namespace Telltale_Script_Editor.Util.GUI
                 StartPosition = FormStartPosition.CenterScreen
             };
             Label textLabel = new Label() { Left = 50, Top = 20, Text = text, AutoSize = true };
-            ComboBox comboBox = new ComboBox() { Left = 50, Top = 50, Width = 400 };
 
-            foreach(string item in comboboxItems)
+            //create a new combobox
+            ComboBox comboBox = new ComboBox() { Left = 50, Top = 50, Width = 400, DropDownStyle = ComboBoxStyle.DropDownList };
+
+            //run a loop to add each of the combobox items string into the actual combobox element
+            foreach (string item in comboboxItems)
             {
                 comboBox.Items.Add(item);
             }
@@ -34,6 +37,7 @@ namespace Telltale_Script_Editor.Util.GUI
             prompt.Controls.Add(textLabel);
             prompt.AcceptButton = confirmation;
 
+            //if the prompt is accepted, return the string of the selected item, otherwise return an empty string
             return prompt.ShowDialog() == DialogResult.OK ? comboBox.SelectedItem.ToString() : "";
         }
     }


### PR DESCRIPTION
1. First change is for the archive script prompt, changes it from a text field into an editable dropdown field where the user can both selected an existing archive folder or write a new one.
2. Second change is a fix for canceling both script creation prompts resulting in a .lua file with no name. Instead, if the user cancels one prompt it does not continue, and if the user cancels the second prompt then it does not continue as well. A new script will only be created if the user successfully goes through both prompts.