### PR TITLE
Prevent NullReferenceException on creation of new script

### DIFF
--- a/Util/GUI/Prompt_Dropdown.cs
+++ b/Util/GUI/Prompt_Dropdown.cs
@@ -40,7 +40,15 @@ namespace Telltale_Script_Editor.Util.GUI
             prompt.AcceptButton = confirmation;
 
             //if the prompt is accepted, return the string of the selected item, otherwise return an empty string
-            return prompt.ShowDialog() == DialogResult.OK ? comboBox.SelectedItem.ToString() : "";
+            if (prompt.ShowDialog() == DialogResult.OK)
+            {
+                //edge case: when the text in the input field does not equal one of the selectable options in the items-list
+                if (comboBox.SelectedItem == null && comboBox.Text != null)
+                    return comboBox.Text;
+                else if (comboBox.SelectedItem != null)
+                    return comboBox.SelectedItem.ToString();
+            }
+            return "";
         }
     }
 }


### PR DESCRIPTION
When creating a new script via `File` → `New` → `Script` the prompt that appears states: 

*Select an existing archive for the script location.*
*Or write a new one into the field.*

When entering text that is not in the dropdown items list, a NullReferenceException is thrown on accessing `comboBox.SelectedItem`.

This pull request fixes this issue by catching this edge case and instead using the property `comboBox.Text`, which is filled with the entered text. The application behaves now according to the text in the prompt.