### PR TITLE
Added settings option to save all open files on Build

### DIFF
--- a/src/renderer/components/modals/SettingsModal.tsx
+++ b/src/renderer/components/modals/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {ActionIcon, Button, Container, Group, NumberInput, Space, Stack, TextInput, Title} from '@mantine/core';
+import {ActionIcon, Button, Container, Group, NumberInput, Space, Stack, TextInput, Title, Checkbox} from '@mantine/core';
 import {AiOutlineFolder} from 'react-icons/ai';
 import {MainProcess} from '../../MainProcessUtils';
 import {useAppDispatch, useAppSelector} from '../../slices/store';
@@ -11,6 +11,7 @@ export const SettingsModal = ({context, id}: ContextModalProps) => {
 	const dispatch = useAppDispatch();
 	const gameExePath = useAppSelector(state => state.storage.gamePath);
 	const maximumBuildsToKeep = useAppSelector(state => state.storage.maximumBuildsToKeep);
+	const saveFilesOnBuild = useAppSelector(state => state.storage.saveFilesOnBuild);
 
 	const handleFolderClicked = async () => {
 		dispatch(OverlayActions.show());
@@ -27,7 +28,7 @@ export const SettingsModal = ({context, id}: ContextModalProps) => {
 			<Title order={1}>Settings</Title>
 			<TextInput
 				required
-				label="Game Executable:"
+				label="Game Executable"
 				placeholder="C:\path\to\WDC.exe"
 				value={gameExePath}
 				onChange={e => dispatch(StorageActions.setGamePath(e.target.value))}
@@ -40,6 +41,12 @@ export const SettingsModal = ({context, id}: ContextModalProps) => {
 				min={0}
 				value={maximumBuildsToKeep}
 				onChange={e => dispatch(StorageActions.setMaximumBuildsToKeep(e ?? 0))}
+			/>
+			<Checkbox
+				required
+				label="Automatically save all open files on Build"
+				checked={saveFilesOnBuild}
+				onChange={e => dispatch(StorageActions.setSaveFilesOnBuild(e.currentTarget.checked))}
 			/>
 			<Space h="xl" />
 			<Group position="right">

--- a/src/renderer/hooks.ts
+++ b/src/renderer/hooks.ts
@@ -5,15 +5,19 @@ import {FileTreeAsyncActions} from './slices/FileTreeSlice';
 import {showNotification} from '@mantine/notifications';
 import {useAppDispatch, useAppSelector} from './slices/store';
 import {StorageActions} from './slices/StorageSlice';
+import {EditorAsyncActions} from "./slices/EditorSlice";
 
 export const useBuildProject = () => {
 	const dispatch = useAppDispatch();
 	const projectPath = useAppSelector(state => state.filetree.root?.path);
 	const project = useAppSelector(state => state.project.currentProject);
 	const gameExePath = useAppSelector(state => state.storage.gamePath);
+	const saveFilesOnBuild = useAppSelector(state => state.storage.saveFilesOnBuild);
 
 	const buildProject = async () => {
 		if (!projectPath || !project) return;
+
+		if (saveFilesOnBuild) await dispatch(EditorAsyncActions.saveAllFiles());
 
 		dispatch(BuildsActions.clearLogs());
 		dispatch(SidebarActions.setActiveTab('logs'));
@@ -39,6 +43,9 @@ export const useBuildProject = () => {
 
 	const buildProjectAndRun = async () => {
 		if (!projectPath || !project) return;
+
+		if (saveFilesOnBuild) await dispatch(EditorAsyncActions.saveAllFiles());
+
 		dispatch(BuildsActions.clearLogs());
 		dispatch(SidebarActions.setActiveTab('logs'));
 

--- a/src/renderer/slices/EditorSlice.ts
+++ b/src/renderer/slices/EditorSlice.ts
@@ -25,6 +25,16 @@ const saveFile = createAsyncThunk('editor/savefile', async (index: number, api) 
 	return index;
 });
 
+const saveAllFiles = createAsyncThunk('editor/saveallfiles', async (_, api) => {
+	const state = api.getState() as AppState;
+
+	for (const file of state.editor.openFiles) {
+		await MainProcess.saveFile({ path: file.file.path, contents: file.contents });
+	}
+
+	return;
+});
+
 const saveFileAndClose = createAsyncThunk('editor/savefileandclose', async (index: number, api) => {
 	const state = api.getState() as AppState;
 	const file = state.editor.openFiles[index];
@@ -99,6 +109,11 @@ export const EditorSlice = createSlice({
 			.addCase(saveFile.fulfilled, (state, { payload: index }) => {
 				state.openFiles[index].hasUnsavedChanges = false;
 			})
+			.addCase(saveAllFiles.fulfilled, (state) => {
+				for (const file of state.openFiles) {
+					file.hasUnsavedChanges = false;
+				}
+			})
 			.addCase(saveFileAndClose.fulfilled, (state, action) => {
 				closeFileReducer(state, action);
 			})
@@ -107,4 +122,4 @@ export const EditorSlice = createSlice({
 
 export const EditorReducer = EditorSlice.reducer;
 export const EditorActions = EditorSlice.actions;
-export const EditorAsyncActions = { openFile, saveFile, saveFileAndClose };
+export const EditorAsyncActions = { openFile, saveFile, saveAllFiles, saveFileAndClose };

--- a/src/renderer/slices/StorageSlice.ts
+++ b/src/renderer/slices/StorageSlice.ts
@@ -10,14 +10,16 @@ interface StorageState {
 	gamePath?: string,
 	sidebarWidth: number,
 	recentProjects: RecentProject[],
-	maximumBuildsToKeep: number
+	maximumBuildsToKeep: number,
+	saveFilesOnBuild: boolean
 }
 
 const initialState: StorageState = {
 	initialised: false,
 	sidebarWidth: 250,
 	recentProjects: [],
-	maximumBuildsToKeep: 5
+	maximumBuildsToKeep: 5,
+	saveFilesOnBuild: true
 };
 
 // NOTE: This is automatically synchronised with a config file on disk to persist data between application restarts.
@@ -39,6 +41,9 @@ export const StorageSlice = createSlice({
 		},
 		setMaximumBuildsToKeep: (state, {payload}: PayloadAction<number>) => {
 			state.maximumBuildsToKeep = payload >= 0 ? payload : 0
+		},
+		setSaveFilesOnBuild: (state, {payload}: PayloadAction<boolean>) => {
+			state.saveFilesOnBuild = payload
 		},
 		setStorageState: (state, {payload}: PayloadAction<StorageState>) => payload
 	}


### PR DESCRIPTION
Coming from Visual Studio, I am so used to my open files automatically being saved when I compile my code, that it was driving me insane having to press a whole *two extra buttons* before being able to Build and Run 😄 

This PR adds a toggleable option in the settings to automatically save all open files (`true` by default) when Building or Building and Running.

Tested locally on Windows 11 with no issues.