### PR TITLE
Option in settings to change editor theme

### DIFF
--- a/src/renderer/components/NoProjectOpen.tsx
+++ b/src/renderer/components/NoProjectOpen.tsx
@@ -109,7 +109,7 @@ export const NoProjectOpen = () => {
 				</div>
 			</Col>
 			{ hasRecentProjects &&
-				<Col span={3} style={{ backgroundColor: '#ebebeb', height: '100%', display: 'flex', flexDirection: 'column' }} p={0}>
+				<Col span={3} style={{ height: '100%', display: 'flex', flexDirection: 'column' }} p={0}>
 					<Title order={3} style={{ textAlign: 'center', borderBottom: '1px solid black' }} py="1rem">Recent Projects</Title>
 					<div style={{ overflowY: 'auto', flexGrow: 1, minHeight: 0 }}>
 						{recentProjects.map(recentProject =>

--- a/src/renderer/components/modals/SettingsModal.tsx
+++ b/src/renderer/components/modals/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {ActionIcon, Button, Container, Group, NumberInput, Space, Stack, TextInput, Title, Checkbox} from '@mantine/core';
+import {ActionIcon, Button, Container, Group, NumberInput, Space, Stack, TextInput, Title, Checkbox, Select} from '@mantine/core';
 import {AiOutlineFolder} from 'react-icons/ai';
 import {MainProcess} from '../../MainProcessUtils';
 import {useAppDispatch, useAppSelector} from '../../slices/store';
@@ -12,6 +12,7 @@ export const SettingsModal = ({context, id}: ContextModalProps) => {
 	const gameExePath = useAppSelector(state => state.storage.gamePath);
 	const maximumBuildsToKeep = useAppSelector(state => state.storage.maximumBuildsToKeep);
 	const saveFilesOnBuild = useAppSelector(state => state.storage.saveFilesOnBuild);
+	const selectedTheme = useAppSelector(state => state.storage.selectedTheme);
 
 	const handleFolderClicked = async () => {
 		dispatch(OverlayActions.show());
@@ -47,6 +48,19 @@ export const SettingsModal = ({context, id}: ContextModalProps) => {
 				label="Automatically save all open files on Build"
 				checked={saveFilesOnBuild}
 				onChange={e => dispatch(StorageActions.setSaveFilesOnBuild(e.currentTarget.checked))}
+			/>
+			<Select
+				required
+				label="Editor Theme"
+				placeholder="Pick one"
+				defaultValue={selectedTheme}
+				data={[
+					{ value: 'light', label: 'A New Day' },
+					{ value: 'dark', label: 'No Time Left' },
+					{ value: 'darkAlt', label: 'All That Remains' },
+					{ value: 'midnight', label: 'A House Divided' },
+				]}
+				onChange={e => dispatch(StorageActions.setTheme(e ?? 'light'))}
 			/>
 			<Space h="xl" />
 			<Group position="right">

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -27,7 +27,7 @@
  */
 
 import * as React from 'react';
-import {createRoot} from 'react-dom/client';
+import {createRoot, Root} from 'react-dom/client';
 import {App} from './components/App';
 import {NotificationsProvider} from '@mantine/notifications';
 import {Provider} from 'react-redux';
@@ -36,19 +36,78 @@ import {ModalsProvider} from '@mantine/modals';
 import {NewProjectModal} from './components/modals/NewProjectModal';
 import {AboutModal} from './components/modals/AboutModal';
 import {SettingsModal} from './components/modals/SettingsModal';
+import {MantineProvider} from "@mantine/core";
 
 const container = document.querySelector('#app');
 
+let selectedTheme = 'light';
+
+// TODO: Replace with a better type, if possible?
+const themes: {[key: string]: [(string | undefined), (string | undefined), (string | undefined), (string | undefined), (string | undefined), (string | undefined), (string | undefined), (string | undefined), (string | undefined), (string | undefined)] | undefined} = {
+	// No Time Left
+	"dark": [
+		'#C1C2C5',
+		'#A6A7AB',
+		'#909296',
+		'#5C5F66',
+		'#373A40',
+		'#2C2E33',
+		'#25262B',
+		'#1A1B1E',
+		'#141517',
+		'#101113'
+	],
+	// All That Remains
+	"darkAlt": [
+		'#F8F9FA',
+		'#F1F3F5',
+		'#E9ECEF',
+		'#DEE2E6',
+		'#CED4DA',
+		'#ADB5BD',
+		'#868E96',
+		'#495057',
+		'#343A40',
+		'#212529'
+	],
+	// A House Divided
+	"midnight": [
+		'#d5d7e0',
+		'#acaebf',
+		'#8c8fa3',
+		'#666980',
+		'#4d4f66',
+		'#34354a',
+		'#2b2c3d',
+		'#1d1e30',
+		'#0c0d21',
+		'#01010a'
+	]
+};
+
+const getProviders = () => {
+	return <React.StrictMode>
+		<Provider store={store}>
+			<MantineProvider theme={{ colorScheme: selectedTheme === 'light' ? 'light' : 'dark', colors: { dark: themes[selectedTheme === 'light' ? 'dark' : selectedTheme] /* If using 'light', 'dark' colors are not changed */ }}} withGlobalStyles withNormalizeCSS>
+				<NotificationsProvider>
+					<ModalsProvider modalProps={{ overlayColor: selectedTheme === 'light' ? 'light' : 'dark' }} modals={{ newproject: NewProjectModal, about: AboutModal, settings: SettingsModal }}>
+						<App />
+					</ModalsProvider>
+				</NotificationsProvider>
+			</MantineProvider>
+		</Provider>
+	</React.StrictMode>;
+}
+
+const renderRoot = (root: Root) => root.render(getProviders());
+
 if (!container) throw new Error('Element with ID "app" not found! Unable to start application!');
 
-createRoot(container).render(
-	<React.StrictMode>
-		<Provider store={store}>
-			<NotificationsProvider>
-				<ModalsProvider modals={{ newproject: NewProjectModal, about: AboutModal, settings: SettingsModal }}>
-					<App />
-				</ModalsProvider>
-			</NotificationsProvider>
-		</Provider>
-	</React.StrictMode>
-);
+const root = createRoot(container);
+
+renderRoot(root);
+
+export const setSelectedTheme = (theme: string) => {
+	selectedTheme = theme;
+	renderRoot(root);
+}

--- a/src/renderer/slices/StorageSlice.ts
+++ b/src/renderer/slices/StorageSlice.ts
@@ -4,6 +4,7 @@ import {MainProcess} from '../MainProcessUtils';
 import {useAppDispatch, useAppSelector} from './store';
 import {RecentProject} from '../types';
 import {createDebouncer} from '../utils';
+import {setSelectedTheme} from '../renderer';
 
 interface StorageState {
 	initialised: boolean,
@@ -11,7 +12,8 @@ interface StorageState {
 	sidebarWidth: number,
 	recentProjects: RecentProject[],
 	maximumBuildsToKeep: number,
-	saveFilesOnBuild: boolean
+	saveFilesOnBuild: boolean,
+	selectedTheme: string
 }
 
 const initialState: StorageState = {
@@ -19,7 +21,8 @@ const initialState: StorageState = {
 	sidebarWidth: 250,
 	recentProjects: [],
 	maximumBuildsToKeep: 5,
-	saveFilesOnBuild: true
+	saveFilesOnBuild: true,
+	selectedTheme: "light"
 };
 
 // NOTE: This is automatically synchronised with a config file on disk to persist data between application restarts.
@@ -45,6 +48,11 @@ export const StorageSlice = createSlice({
 		setSaveFilesOnBuild: (state, {payload}: PayloadAction<boolean>) => {
 			state.saveFilesOnBuild = payload
 		},
+		setTheme: (state, {payload}: PayloadAction<string>) => {
+			state.selectedTheme = payload;
+
+			setSelectedTheme(payload);
+		},
 		setStorageState: (state, {payload}: PayloadAction<StorageState>) => payload
 	}
 });
@@ -68,7 +76,11 @@ export const useStorageStateSync = () => {
 
 				setInitialised(true);
 			} else {
-				debounce(() => MainProcess.updateAppState(state), 500);
+				debounce(() => {
+					MainProcess.updateAppState(state);
+
+					setSelectedTheme(state.storage.selectedTheme);
+				}, 500);
 			}
 		})();
 	}, [initialised, state]);


### PR DESCRIPTION
No more being blinded when trying to work past midnight!

Adds an option in the settings to select from one of four themes:

- A New Day (Light)
    - Stock Light Mode, no changes
    - ![image](https://user-images.githubusercontent.com/10535902/193506219-16f5f3d0-4052-4280-be1f-70ca39e9d22b.png)
- No Time Left (Dark)
    - ![image](https://user-images.githubusercontent.com/10535902/193506238-1a496109-e880-42a8-b438-8682c7061a5e.png)
- All That Remains (Dark Alternative)
    - ![image](https://user-images.githubusercontent.com/10535902/193506264-4b4b1b90-2e67-49a2-8446-a8cd96af45b6.png)
- A House Divided (Midnight)
    - ![image](https://user-images.githubusercontent.com/10535902/193506289-507899bf-71ac-470b-8247-e1a3540fe24a.png)

More themes can be added by contributors.

Tested on Windows 11 with no issues.