### PR TITLE
Add new projects to Recent Project list

### DIFF
--- a/src/renderer/components/modals/NewProjectModal.tsx
+++ b/src/renderer/components/modals/NewProjectModal.tsx
@@ -10,6 +10,7 @@ import {FileTreeActions} from '../../slices/FileTreeSlice';
 import {ProjectActions} from '../../slices/ProjectSlice';
 import {formatProjectName} from '../../../shared/utils';
 import {OverlayActions} from '../../slices/OverlaySlice';
+import {StorageActions} from "../../slices/StorageSlice";
 
 export const NewProjectModal = ({context, id}: ContextModalProps) => {
 	const dispatch = useAppDispatch();
@@ -32,6 +33,12 @@ export const NewProjectModal = ({context, id}: ContextModalProps) => {
 
 		dispatch(FileTreeActions.setRootDirectory(root));
 		dispatch(ProjectActions.setProject(project));
+
+		if (root.directory && root.children) {
+			const tseprojPath = root.children.find(child => child.path.endsWith('.tseproj'))?.path;
+
+			if (tseprojPath) dispatch(StorageActions.addRecentProject({project, tseprojPath}));
+		}
 
 		context.closeModal(id);
 	};


### PR DESCRIPTION
Caught me off guard that I had to explicitly open my project in order for it to be added to the Recent Project list.

When new projects are created, they are immediately added to the Recent Projects list.

Tested on Windows 11 with no issues.