### PR TITLE
Add GitHub Action to lint files on Push

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,23 @@
+name: Linting
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm install
+    - run: npm run lint

--- a/src/main/handlers/IPCHandlers.ts
+++ b/src/main/handlers/IPCHandlers.ts
@@ -24,7 +24,6 @@ import {
 import * as path from 'path';
 import {formatProjectName} from '../../shared/utils';
 import {execFile} from 'child_process';
-import AdmZip from 'adm-zip';
 import {updateEditorMenu} from '../EditorMenu';
 import {buildProject} from './BuildProject';
 import Store from 'electron-store';

--- a/src/renderer/ProjectUtils.ts
+++ b/src/renderer/ProjectUtils.ts
@@ -15,8 +15,8 @@ export const openProject = (dispatch: AppDispatch, root: EditorFile, project: Pr
 	dispatch(FileTreeActions.setRootDirectory(root));
 	dispatch(ProjectActions.setProject(project));
 
-	const tseprojPath = root.children.find(child => child.path.endsWith('.tseproj'))!.path;
-	dispatch(StorageActions.addRecentProject({project, tseprojPath}));
+	const tseprojPath = root.children.find(child => child.path.endsWith('.tseproj'))?.path;
+	if (tseprojPath) dispatch(StorageActions.addRecentProject({project, tseprojPath}));
 };
 
 export const handleOpenProject = async (dispatch: AppDispatch) => {

--- a/src/renderer/components/Builds.tsx
+++ b/src/renderer/components/Builds.tsx
@@ -1,12 +1,12 @@
 import styles from './Sidebar.module.css';
-import {ActionIcon, Button, Code, Group, MediaQuery, Stack} from '@mantine/core';
+import {ActionIcon, Button, Code, Group, Stack} from '@mantine/core';
 import * as React from 'react';
 import {useAppDispatch, useAppSelector} from '../slices/store';
 import {BuildsActions} from '../slices/BuildsSlice';
 import {MainProcess} from '../MainProcessUtils';
 import {BsFillTrashFill} from 'react-icons/bs';
 import {showNotification} from '@mantine/notifications';
-import {FileTreeActions, FileTreeAsyncActions} from '../slices/FileTreeSlice';
+import {FileTreeAsyncActions} from "../slices/FileTreeSlice";
 
 export const Builds = () => {
 	const dispatch = useAppDispatch();

--- a/src/renderer/components/NoProjectOpen.tsx
+++ b/src/renderer/components/NoProjectOpen.tsx
@@ -8,7 +8,7 @@ import {MainProcess} from '../MainProcessUtils';
 import {RecentProject} from '../types';
 import {OverlayActions} from '../slices/OverlaySlice';
 import {showNotification} from '@mantine/notifications';
-import {StorageActions, StorageSlice} from '../slices/StorageSlice';
+import {StorageActions} from '../slices/StorageSlice';
 import {handleOpenProject, openProject} from '../ProjectUtils';
 import {dirname} from '../utils';
 import {useState} from 'react';

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -60,7 +60,7 @@ export const Editor = ({ onChange, mode }: EditorProps) => {
 		defaultLanguage={mode}
 		defaultValue={activeFile.contents}
 		theme="vs-dark"
-		onChange={contents => handleEditorChange(contents!)}
+		onChange={contents => handleEditorChange(contents as string)}
 		onMount={monaco => editorRef.current = monaco}
 	/>
 };


### PR DESCRIPTION
This adds linting via GitHub actions when a commit is pushed. Linting issues are flagged as errors, so they won't fail an action.